### PR TITLE
Increased the speed of _transition_matrix_dense twofold

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -70,7 +70,7 @@ jobs:
           name: dist
           path: dist  # unmangle to `./dist` to actually publish
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1.8.5
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -70,7 +70,7 @@ jobs:
           name: dist
           path: dist  # unmangle to `./dist` to actually publish
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1.8.5
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_PASSWORD }}

--- a/src/nmrsim/qm.py
+++ b/src/nmrsim/qm.py
@@ -281,7 +281,12 @@ def _transition_matrix_dense(nspins):
     T = np.zeros((n, n))
     for i in range(n - 1):
         for j in range(i + 1, n):
-            if bin(i ^ j).count("1") == 1:
+            m = i ^ j
+            # Check if m is a power of two:
+            # If m is a power of two, it will look like 100[...]00 in binary
+            # m-1 will look like 011[...]11 in binary.
+            # Using a binary and, we should then get 0.
+            if m > 0 and m & (m-1) == 0:
                 T[i, j] = 1
     T += T.T
     return T


### PR DESCRIPTION
A small tweak the `_transition_matrix_dense` seems to increase its speed twofold.

Original code (`nspins=8`):
`_transition_matrix_dense took 33.4841s for 10000 runs`

New code:
`_transition_matrix_dense took 16.7938s for 10000 runs`

The equivalence has been verified for good measure as such:
```
for i in range(100):
    for j in range(100):
        m = i ^ j
        flag1 = bin(i ^ j).count("1") == 1

        flag2 = False
        if m > 0 and m & (m-1) == 0:
            flag2 = True

        assert flag1 == flag2
```
