### PR TITLE
Added an alternative way to generate first-order multiplets with better scaling

### DIFF
--- a/src/nmrsim/firstorder.py
+++ b/src/nmrsim/firstorder.py
@@ -8,7 +8,7 @@ The nmrsim.firstorder module provides the following functions:
     same v/J parameters that are used for second-order spin systems.
     See nmrsim.qm for details on these parameters.
 """
-from scipy.special import binom
+from math import comb
 
 from nmrsim.math import reduce_peaks
 
@@ -98,7 +98,7 @@ def _multiplet(signal, coupling):
     new_signal = []
 
     # Precalculate binomial coefficients
-    coeffs = [binom(nsplit, i) for i in range(nsplit + 1)]
+    coeffs = [comb(nsplit, i) for i in range(nsplit + 1)]
     normalization_constant = intensity / sum(coeffs)
     for i in range(nsplit + 1):
         new_signal.append((first_peak + i * J, coeffs[i] * normalization_constant))


### PR DESCRIPTION
The current method of generating multiplets (splitting multiple times into doublets) scales exponentially with the multiplicity. An alternative way to generate multiplets was implemented using binomial coefficients. It's faster for high multiplicities (although slower for simple cases) while remaining pretty elegant. The code is not currently used by the other functions, I let you judge whether it would be useful to use elsewhere in the codebase.

Benchmark results:
```
Couplings: [(8, 2), (4, 2)]
Current: 0.0466 s for 10000 iterations
New: 0.1685 s for 10000 iterations

Couplings: [(8, 2), (4, 2), (7, 3), (1.5, 3)]
Current: 2.5646 s for 10000 iterations
New: 2.5093 s for 10000 iterations

Couplings: [(8, 8), (4, 5)]
Current: 21.5207 s for 10000 iterations
New: 0.8021 s for 10000 iterations

Couplings: [(13, 8), (7, 5)]
Current: 22.7828 s for 10000 iterations
New: 0.8319 s for 10000 iterations
```

Verification and benchmarking code:
```
import time

from nmrsim.firstorder import multiplet, binomial_multiplet

def equivalent(peak1, peak2):
    if len(peak1) != len(peak2):
        return False
    for p1, p2 in zip(peak1, peak2):
        for c1, c2 in zip(p1, p2):
            if abs(c1 - c2) > 1e-9:
                return False
    return True

for i in range(1, 10):
    for j in range(1, 10):
        ref = multiplet((300, 1), [(13, i), (7, j)])
        comp = binomial_multiplet((300, 1), [(13, i), (7, j)])
        assert equivalent(ref, comp)

N = 10000

for case in [
    [(8, 2), (4, 2)],
    [(8, 2), (4, 2), (7, 3), (1.5, 3)],
    [(8, 8), (4, 5)],
    [(13, 8), (7, 5)],
]:
    t1 = time.time()
    for i in range(N):
        multiplet((300, 1), case)
    t2 = time.time()
    print(case)

    print(f"Current: {t2-t1:.4f} s for {N} iterations")
    t1 = time.time()
    for i in range(N):
        binomial_multiplet((300, 1), case)
    t2 = time.time()

    print(f"New: {t2-t1:.4f} s for {N} iterations")
    print("")
```

I also noticed a slight confusion regarding the notation of the multiplicities. Currently, a coupling of the form `(8, 2)` will produce a triplet with `J = 8 Hz`, as it causes the signal to split twice. The docstring of the multiplet function previously indicated that `(8, 2)` would produce a doublet.